### PR TITLE
fix docker build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Custom base container for running [Nix](https://nixos.org/nix/) inside [Act](htt
 All you need is the `Dockerfile` from this repo, but there is also a demo `ci.yml` so you can verify thta it works. So build the image locally:
 
 ```
-docker build -t dsyer/ubuntu:act-latest
+docker build -t dsyer/ubuntu:act-latest .
 ```
 
 and then run it:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Custom base container for running [Nix](https://nixos.org/nix/) inside [Act](https://github.com/nektos/act). Act is awesome. It lets you run Github Actions locally (in docker), so you can fix bugs in your CI without pushing and waiting for Github to churn through the actions.
 
-All you need is the `Dockerfile` from this repo, but there is also a demo `ci.yml` so you can verify thta it works. So build the image locally:
+All you need is the `Dockerfile` from this repo, but there is also a demo `ci.yml` so you can verify that it works. So build the image locally:
 
 ```
 docker build -t dsyer/ubuntu:act-latest .


### PR DESCRIPTION
Thanks for working on this @dsyer, I thought I'd repay the favor with an update :)

The old command fails on docker 20.10.16 with:
```
"docker build" requires exactly 1 argument.
```